### PR TITLE
Fix Python package build with modern setuptools

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include grammars/bsl/queries *.scm
+recursive-include grammars/bsl/src/tree_sitter *.h
+recursive-include grammars/sdbl/src/tree_sitter *.h

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=70.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,8 @@ from platform import system
 from sysconfig import get_config_var
 
 from setuptools import Extension, find_packages, setup
-from setuptools._distutils.command.build import build
-from setuptools.command.egg_info import egg_info
-from wheel.bdist_wheel import bdist_wheel
+from setuptools.command.bdist_wheel import bdist_wheel
+from setuptools.command.build import build
 
 sources = [
     "bindings/python/tree_sitter_bsl/binding.c",
@@ -45,13 +44,6 @@ class BdistWheel(bdist_wheel):
         return python, abi, platform
 
 
-class EggInfo(egg_info):
-    def find_sources(self):
-        super().find_sources()
-        self.filelist.recursive_include("grammars/bsl/queries", "*.scm")
-        self.filelist.include("grammars/bsl/src/tree_sitter/*.h")
-
-
 setup(
     packages=find_packages("bindings/python"),
     package_dir={"": "bindings/python"},
@@ -73,7 +65,6 @@ setup(
     cmdclass={
         "build": Build,
         "bdist_wheel": BdistWheel,
-        "egg_info": EggInfo,
     },
     zip_safe=False
 )


### PR DESCRIPTION
## Summary
- use setuptools-provided build and bdist_wheel commands instead of distutils/wheel legacy imports
- move query/header sdist includes into MANIFEST.in
- require setuptools>=70.1 in the build backend

## Why
Installing v0.1.7 from GitHub as a Python package fails on Python 3.12 with current isolated build environments before compilation starts:

```
ImportError: cannot import name 'sdist' from 'setuptools._distutils.command'
```

The failure is triggered by the custom egg_info import path and legacy wheel.bdist_wheel import.

## Verification
- `uv run --no-project --python 3.12 --with build python -m build --wheel --sdist`
- installed the built wheel with `tree-sitter==0.25.2` on Python 3.12
- smoke parsed BSL source and verified `sdbl_language` is exported


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Обновлены конфигурации пакета для правильного распространения файлов грамматик в дистрибутиве
  * Обновлены зависимости и требования для процесса сборки пакета

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkoleft/tree-sitter-bsl/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->